### PR TITLE
Configurar un DAG, grupo de universidades D - OT301-24

### DIFF
--- a/airflow/dags/GDUNTresDeFebrero_dag_etl.py
+++ b/airflow/dags/GDUNTresDeFebrero_dag_etl.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from datetime import timedelta
+
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+
+default_args={
+    'owner': 'Alkemy',
+    'start_date': datetime(2022, 9, 19)
+}
+
+with DAG(dag_id='UNTresDeFebrero_dag_etl',
+        description='Universidad Nacional Tres de Febrero proceso ETL',
+        start_date=datetime(2022,9,19),
+        schedule_interval=timedelta(hours=1),
+        default_args=default_args,
+) as dag:
+
+    # Extraccion de archivos desde base SQL
+    extract = DummyOperator(
+        task_id='extraccion'
+    )
+
+    # Transformacion con pandas
+    transform = DummyOperator(
+        task_id = 'transformacion'
+    )
+
+    # Carga de datos en S3
+    load = DummyOperator(
+        task_id = 'carga'
+    )
+
+extract >> transform >> load

--- a/airflow/dags/GDUTN_dag_etl.py
+++ b/airflow/dags/GDUTN_dag_etl.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from datetime import timedelta
+
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+
+default_args={
+    'owner': 'Alkemy',
+    'start_date': datetime(2022, 9, 19)
+}
+
+with DAG(dag_id='UTN_dag_etl',
+        description='Universidad Tecnolgogica Nacional proceso ETL',
+        start_date=datetime(2022,9,19),
+        schedule_interval=timedelta(hours=1),
+        default_args=default_args,
+) as dag:
+
+    # Extraccion de archivos desde base SQL
+    extract = DummyOperator(
+        task_id='extraccion'
+    )
+
+    # Transformacion con pandas
+    transform = DummyOperator(
+        task_id = 'transformacion'
+    )
+
+    # Carga de datos en S3
+    load = DummyOperator(
+        task_id = 'carga'
+    )
+
+extract >> transform >> load


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT301-24

Descripción:

COMO: Analista de datos
QUIERO: Configurar un DAG, sin consultas, ni procesamiento
PARA: Hacer un ETL para 2 universidades distintas.

Criterios de aceptación: 
Configurar el DAG para procese las siguientes universidades:

Universidad Tecnológica Nacional

Universidad Nacional De Tres De Febrero
Documentar los operators que se deberían utilizar a futuro, teniendo en cuenta que se va a hacer dos consultas SQL (una para cada universidad), se van a procesar los datos con pandas y se van a cargar los datos en S3.  El DAG se debe ejecutar cada 1 hora, todos los días.